### PR TITLE
[FIX] Prevent spam of errors when access to vote channel is denied

### DIFF
--- a/src/cronjobs.ts
+++ b/src/cronjobs.ts
@@ -234,7 +234,7 @@ async function endVote(vote: Vote, bot: Client) {
 		console.error(JSON.stringify(error, null, 2));
 		// eslint-disable-next-line eqeqeq
 		if (error.httpStatus != 404 /*  'DiscordAPIError: Unknown Message' */) {
-			throw new Error(error);
+			throw error;
 		}
 	}
 }


### PR DESCRIPTION
Previously the error was cascaded into a new error with name === "Error" and message === "DiscordAPIError: Missing Access". To prevent this we remove the cascading of the error